### PR TITLE
Add info about xzip.bin to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The `.pre` and `.pur` files concatenate to the original, except that in ziptest.
 
 ## basic: GW-BASIC
 
-* xzip.bin: ZIP binary (possibly C64, as it starts with the bytes "CBM")
+* xzip.bin: ZIP binary (C128 auto-boot disk)
 * *.bas: BASIC bytecode for receiving files over a serial connection
 
 Not sure why there are several versions of the BASIC script. They all start by printing "IBM TFTP RECEIVER", but they diverge from there.


### PR DESCRIPTION

The `xzip.bin` file is definitely meant to run on a C128, not C64. It's a C128 auto-boot disk. The boot sector format is described in the _Commodore 128 Programmer's Reference Guide_ on page 446 (documentation for `$FF53 BOOT CALL`). See https://www.pagetable.com/docs/Commodore%20128%20Programmer%27s%20Reference%20Guide.pdf for reference.

Further, the code starting at offset 9 in `xzip.bin` calls a kernal routine which is only available on the C128 (`$FF5F`, SWAPPER), and configures the MMU register `$D506`, also only available on the C128.

It should actually be possible to boot this image in VICE.

Seems like `basic/xzip.bin` was once built from the source files found in `c-128/xzip/`.